### PR TITLE
Fix/611 reenable email new user notification with password

### DIFF
--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -70,8 +70,8 @@ depot_storage_name = test
 depot_storage_dir = /tmp/test/depot
 user.auth_token.validity = 604800
 preview_cache_dir = /tmp/test/preview_cache
-email.notification.activated = false
 preview.jpg.restricted_dims = True
+email.notification.activated = false
 
 [functional_test_no_db]
 sqlalchemy.url = sqlite://
@@ -79,5 +79,54 @@ depot_storage_name = test
 depot_storage_dir = /tmp/test/depot
 user.auth_token.validity = 604800
 preview_cache_dir = /tmp/test/preview_cache
-email.notification.activated = false
 preview.jpg.restricted_dims = True
+email.notification.activated = false
+
+[functional_test_with_mail_test_sync]
+sqlalchemy.url = sqlite:///tracim_test.sqlite
+depot_storage_name = test
+depot_storage_dir = /tmp/test/depot
+user.auth_token.validity = 604800
+preview_cache_dir = /tmp/test/preview_cache
+preview.jpg.restricted_dims = True
+email.notification.activated = true
+email.notification.from.email = test_user_from+{user_id}@localhost
+email.notification.from.default_label = Tracim Notifications
+email.notification.reply_to.email = test_user_reply+{content_id}@localhost
+email.notification.references.email = test_user_refs+{content_id}@localhost
+email.notification.content_update.template.html = %(here)s/tracim_backend/templates/mail/content_update_body_html.mak
+email.notification.content_update.template.text = %(here)s/tracim_backend/templates/mail/content_update_body_text.mak
+email.notification.created_account.template.html = %(here)s/tracim_backend/templates/mail/created_account_body_html.mak
+email.notification.created_account.template.text = %(here)s/tracim_backend/templates/mail/created_account_body_text.mak
+email.notification.content_update.subject = [{website_title}] [{workspace_label}] {content_label} ({content_status_label})
+email.notification.created_account.subject = [{website_title}] Created account
+email.notification.processing_mode = sync
+email.notification.smtp.server = 127.0.0.1
+email.notification.smtp.port = 1025
+email.notification.smtp.user = test_user
+email.notification.smtp.password = just_a_password
+
+
+[functional_test_with_mail_test_async]
+sqlalchemy.url = sqlite:///tracim_test.sqlite
+depot_storage_name = test
+depot_storage_dir = /tmp/test/depot
+user.auth_token.validity = 604800
+preview_cache_dir = /tmp/test/preview_cache
+preview.jpg.restricted_dims = True
+email.notification.activated = true
+email.notification.from.email = test_user_from+{user_id}@localhost
+email.notification.from.default_label = Tracim Notifications
+email.notification.reply_to.email = test_user_reply+{content_id}@localhost
+email.notification.references.email = test_user_refs+{content_id}@localhost
+email.notification.content_update.template.html = %(here)s/tracim_backend/templates/mail/content_update_body_html.mak
+email.notification.content_update.template.text = %(here)s/tracim_backend/templates/mail/content_update_body_text.mak
+email.notification.created_account.template.html = %(here)s/tracim_backend/templates/mail/created_account_body_html.mak
+email.notification.created_account.template.text = %(here)s/tracim_backend/templates/mail/created_account_body_text.mak
+email.notification.content_update.subject = [{website_title}] [{workspace_label}] {content_label} ({content_status_label})
+email.notification.created_account.subject = [{website_title}] Created account
+email.notification.processing_mode = async
+email.notification.smtp.server = 127.0.0.1
+email.notification.smtp.port = 1025
+email.notification.smtp.user = test_user
+email.notification.smtp.password = just_a_password

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -63,3 +63,21 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+
+[functional_test]
+sqlalchemy.url = sqlite:///tracim_test.sqlite
+depot_storage_name = test
+depot_storage_dir = /tmp/test/depot
+user.auth_token.validity = 604800
+preview_cache_dir = /tmp/test/preview_cache
+email.notification.activated = false
+preview.jpg.restricted_dims = True
+
+[functional_test_no_db]
+sqlalchemy.url = sqlite://
+depot_storage_name = test
+depot_storage_dir = /tmp/test/depot
+user.auth_token.validity = 604800
+preview_cache_dir = /tmp/test/preview_cache
+email.notification.activated = false
+preview.jpg.restricted_dims = True

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -160,9 +160,11 @@ class CFG(object):
 
         self.EMAIL_NOTIFICATION_FROM_EMAIL = settings.get(
             'email.notification.from.email',
+            'noreply+{user_id}@trac.im'
         )
         self.EMAIL_NOTIFICATION_FROM_DEFAULT_LABEL = settings.get(
-            'email.notification.from.default_label'
+            'email.notification.from.default_label',
+            'Tracim Notifications'
         )
         self.EMAIL_NOTIFICATION_REPLY_TO_EMAIL = settings.get(
             'email.notification.reply_to.email',

--- a/backend/tracim_backend/lib/utils/utils.py
+++ b/backend/tracim_backend/lib/utils/utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
+import random
+import string
 from redis import Redis
 from rq import Queue
 
@@ -72,3 +74,25 @@ def current_date_for_filename() -> str:
     # webdav utils, it may cause trouble. So, it should be replaced to
     # a character which will not change in bdd.
     return datetime.datetime.now().isoformat().replace(':', '.')
+
+# INFO - G.M - 2018-08-02 - Simple password generator, inspired by
+# https://gist.github.com/23maverick23/4131896
+
+
+ALLOWED_AUTOGEN_PASSWORD_CHAR = string.ascii_letters + \
+                                string.digits + \
+                                string.punctuation
+
+DEFAULT_PASSWORD_GEN_CHAR_LENGTH = 12
+
+
+def password_generator(
+        length: int=DEFAULT_PASSWORD_GEN_CHAR_LENGTH,
+        chars: str=ALLOWED_AUTOGEN_PASSWORD_CHAR
+) -> str:
+    """
+    :param length: length of the new password
+    :param chars: characters allowed
+    :return: password as string
+    """
+    return ''.join(random.choice(chars) for char_number in range(length))

--- a/backend/tracim_backend/tests/__init__.py
+++ b/backend/tracim_backend/tests/__init__.py
@@ -68,20 +68,17 @@ def create_1000px_png_test_image():
 class FunctionalTest(unittest.TestCase):
 
     fixtures = [BaseFixture]
-    sqlalchemy_url = 'sqlite:///tracim_test.sqlite'
+    config_uri = 'tests_configs.ini'
+    config_section = 'functional_test'
 
     def setUp(self):
         logger._logger.setLevel('WARNING')
+
         DepotManager._clear()
-        self.settings = {
-            'sqlalchemy.url': self.sqlalchemy_url,
-            'user.auth_token.validity': '604800',
-            'depot_storage_dir': '/tmp/test/depot',
-            'depot_storage_name': 'test',
-            'preview_cache_dir': '/tmp/test/preview_cache',
-            'preview.jpg.restricted_dims': True,
-            'email.notification.activated': 'false',
-        }
+        self.settings = plaster.get_settings(
+            self.config_uri,
+            self.config_section
+        )
         hapic.reset_context()
         self.engine = get_engine(self.settings)
         DeclarativeBase.metadata.create_all(self.engine)
@@ -127,7 +124,7 @@ class FunctionalTestEmptyDB(FunctionalTest):
 
 
 class FunctionalTestNoDB(FunctionalTest):
-    sqlalchemy_url = 'sqlite://'
+    config_section = 'functional_test_no_db'
 
     def init_database(self, settings):
         self.engine = get_engine(settings)

--- a/backend/tracim_backend/tests/library/tests_utils.py
+++ b/backend/tracim_backend/tests/library/tests_utils.py
@@ -1,0 +1,14 @@
+import string
+
+from tracim_backend.lib.utils.utils import password_generator
+from tracim_backend.lib.utils.utils import ALLOWED_AUTOGEN_PASSWORD_CHAR
+from tracim_backend.lib.utils.utils import DEFAULT_PASSWORD_GEN_CHAR_LENGTH
+
+
+class TestPasswordGenerator(object):
+
+    def test_password_generator_ok_nominal_case(self):
+        password = password_generator()
+        assert len(password) == DEFAULT_PASSWORD_GEN_CHAR_LENGTH
+        for char in password:
+            assert char in ALLOWED_AUTOGEN_PASSWORD_CHAR

--- a/backend/tracim_backend/views/core_api/workspace_controller.py
+++ b/backend/tracim_backend/views/core_api/workspace_controller.py
@@ -214,11 +214,16 @@ class WorkspaceController(Controller):
                 # notification for creation
                 user = uapi.create_user(
                     hapic_data.body.user_email_or_public_name,
-                    do_notify=False
+                    do_notify=True
                 )  # nopep8
                 newly_created = True
+                if app_config.EMAIL_NOTIFICATION_ACTIVATED and \
+                        app_config.EMAIL_PROCESSING_MODE == 'SYNC':
+                    email_sent = True
+
             except EmailValidationFailed:
                 raise UserCreationFailed('no valid mail given')
+
         role = rapi.create_one(
             user=user,
             workspace=request.current_workspace,

--- a/backend/tracim_backend/views/core_api/workspace_controller.py
+++ b/backend/tracim_backend/views/core_api/workspace_controller.py
@@ -31,6 +31,7 @@ from tracim_backend.exceptions import ContentNotFound
 from tracim_backend.exceptions import WorkspacesDoNotMatch
 from tracim_backend.exceptions import ParentNotFound
 from tracim_backend.views.controllers import Controller
+from tracim_backend.lib.utils.utils import password_generator
 from tracim_backend.views.core_api.schemas import FilterContentQuerySchema
 from tracim_backend.views.core_api.schemas import WorkspaceMemberCreationSchema
 from tracim_backend.views.core_api.schemas import WorkspaceMemberInviteSchema
@@ -213,7 +214,8 @@ class WorkspaceController(Controller):
                 # TODO - G.M - 2018-07-05 - [UserCreation] Reenable email
                 # notification for creation
                 user = uapi.create_user(
-                    hapic_data.body.user_email_or_public_name,
+                    email=hapic_data.body.user_email_or_public_name,
+                    password= password_generator(),
                     do_notify=True
                 )  # nopep8
                 newly_created = True

--- a/backend/tracim_backend/views/core_api/workspace_controller.py
+++ b/backend/tracim_backend/views/core_api/workspace_controller.py
@@ -218,7 +218,7 @@ class WorkspaceController(Controller):
                 )  # nopep8
                 newly_created = True
                 if app_config.EMAIL_NOTIFICATION_ACTIVATED and \
-                        app_config.EMAIL_PROCESSING_MODE == 'SYNC':
+                        app_config.EMAIL_NOTIFICATION_PROCESSING_MODE.lower() == 'sync':
                     email_sent = True
 
             except EmailValidationFailed:


### PR DESCRIPTION
- [x] Fix Functional test in order to use ini file like any other
- [x] Reenable email notification for user, fix broken code (need default value in conf)
- [x] Support for email_sent param has true in invite endpoint if email is send synchronously.
- [x] Add autogenerated password system used for account create this way.