### PR TITLE
remove python 3.4 travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ matrix:
     - sudo: false
       language: python
       python:
-        - "3.4"
         - "3.5"
         - "3.6"
 


### PR DESCRIPTION
remove python 3.4 from travis test to avoid error related to hapic modification (not anymore compatible with python 3.4 due to async syntax)