### PR TITLE
Fix/834 endpoint enable disable notification

### DIFF
--- a/backend/tracim_backend/models/context_models.py
+++ b/backend/tracim_backend/models/context_models.py
@@ -266,10 +266,8 @@ class RoleUpdate(object):
     def __init__(
         self,
         role: str,
-        do_notify: bool,
     ):
         self.role = role
-        self.do_notify = do_notify
 
 
 class WorkspaceMemberInvitation(object):
@@ -281,12 +279,10 @@ class WorkspaceMemberInvitation(object):
         user_id: int,
         user_email_or_public_name: str,
         role: str,
-        do_notify: str,
     ):
         self.role = role
         self.user_email_or_public_name = user_email_or_public_name
         self.user_id = user_id
-        self.do_notify = do_notify
 
 
 class WorkspaceUpdate(object):

--- a/backend/tracim_backend/models/context_models.py
+++ b/backend/tracim_backend/models/context_models.py
@@ -169,7 +169,7 @@ class WorkspaceAndUserPath(object):
     """
     def __init__(self, workspace_id: int, user_id: int):
         self.workspace_id = workspace_id
-        self.user_id = workspace_id
+        self.user_id = user_id
 
 
 class UserWorkspaceAndContentPath(object):

--- a/backend/tracim_backend/tests/functional/test_workspaces.py
+++ b/backend/tracim_backend/tests/functional/test_workspaces.py
@@ -980,7 +980,6 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
             'user_id': 2,
             'user_email_or_public_name': None,
             'role': 'content-manager',
-            'do_notify': False,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1023,7 +1022,6 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
             'user_id': None,
             'user_email_or_public_name': 'lawrence-not-real-email@fsf.local',
             'role': 'content-manager',
-            'do_notify': 'True',
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1036,7 +1034,7 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
         assert user_role_found['workspace_id'] == 1
         assert user_role_found['newly_created'] is False
         assert user_role_found['email_sent'] is False
-        assert user_role_found['do_notify'] is True
+        assert user_role_found['do_notify'] is False
 
         res = self.testapp.get('/api/v2/workspaces/1/members', status=200).json_body   # nopep8
         assert len(res) == 2
@@ -1066,7 +1064,6 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
             'user_id': None,
             'user_email_or_public_name': 'Lawrence L.',
             'role': 'content-manager',
-            'do_notify': True,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1079,7 +1076,7 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
         assert user_role_found['workspace_id'] == 1
         assert user_role_found['newly_created'] is False
         assert user_role_found['email_sent'] is False
-        assert user_role_found['do_notify'] is True
+        assert user_role_found['do_notify'] is False
 
         res = self.testapp.get('/api/v2/workspaces/1/members', status=200).json_body   # nopep8
         assert len(res) == 2
@@ -1109,7 +1106,6 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
             'user_id': None,
             'user_email_or_public_name': None,
             'role': 'content-manager',
-            'do_notify': True,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1134,7 +1130,6 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
             'user_id': 47,
             'user_email_or_public_name': None,
             'role': 'content-manager',
-            'do_notify': True,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1159,7 +1154,6 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
             'user_id': None,
             'user_email_or_public_name': 'nothing@nothing.nothing',
             'role': 'content-manager',
-            'do_notify': True,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1173,7 +1167,7 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
         assert user_role_found['workspace_id'] == 1
         assert user_role_found['newly_created'] is True
         assert user_role_found['email_sent'] is False
-        assert user_role_found['do_notify'] is True
+        assert user_role_found['do_notify'] is False
 
         res = self.testapp.get('/api/v2/workspaces/1/members',
                                status=200).json_body  # nopep8
@@ -1205,10 +1199,10 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
         assert user_role['role'] == 'workspace-manager'
         assert user_role['user_id'] == 1
         assert user_role['workspace_id'] == 1
+        assert user_role['do_notify'] is True
         # update workspace role
         params = {
             'role': 'content-manager',
-            'do_notify': False,
         }
         res = self.testapp.put_json(
             '/api/v2/workspaces/1/members/1',
@@ -1224,7 +1218,7 @@ class TestWorkspaceMembersEndpoint(FunctionalTest):
         assert len(res) == 1
         user_role = res[0]
         assert user_role['role'] == 'content-manager'
-        assert user_role['do_notify'] is False
+        assert user_role['do_notify'] is True
         assert user_role['user_id'] == 1
         assert user_role['workspace_id'] == 1
 
@@ -1367,7 +1361,6 @@ class TestUserInvitationWithMailActivatedSync(FunctionalTest):
             'user_id': None,
             'user_email_or_public_name': 'bob@bob.bob',
             'role': 'content-manager',
-            'do_notify': True,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',
@@ -1381,7 +1374,7 @@ class TestUserInvitationWithMailActivatedSync(FunctionalTest):
         assert user_role_found['workspace_id'] == 1
         assert user_role_found['newly_created'] is True
         assert user_role_found['email_sent'] is True
-        assert user_role_found['do_notify'] is True
+        assert user_role_found['do_notify'] is False
 
         # check mail received
         response = requests.get('http://127.0.0.1:8025/api/v1/messages')
@@ -1418,7 +1411,6 @@ class TestUserInvitationWithMailActivatedASync(FunctionalTest):
             'user_id': None,
             'user_email_or_public_name': 'bob@bob.bob',
             'role': 'content-manager',
-            'do_notify': True,
         }
         res = self.testapp.post_json(
             '/api/v2/workspaces/1/members',

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -466,12 +466,6 @@ class RoleUpdateSchema(marshmallow.Schema):
         example='contributor',
         validate=OneOf(UserRoleInWorkspace.get_all_role_slug())
     )
-    do_notify = marshmallow.fields.Bool(
-        description='has user enabled notification for this workspace',
-        example=True,
-        default=None,
-        allow_none=True,
-    )
 
     @post_load
     def make_role(self, data):

--- a/backend/tracim_backend/views/core_api/user_controller.py
+++ b/backend/tracim_backend/views/core_api/user_controller.py
@@ -1,4 +1,5 @@
 from pyramid.config import Configurator
+from tracim_backend.lib.core.userworkspace import RoleApi
 from tracim_backend.lib.utils.utils import password_generator
 
 try:  # Python 3.5+
@@ -458,6 +459,60 @@ class UserController(Controller):
         api.mark_read__workspace(request.current_workspace)
         return
 
+    @hapic.with_api_doc(tags=[SWAGGER_TAG__USER_ENDPOINTS])
+    @require_same_user_or_profile(Group.TIM_ADMIN)
+    @hapic.input_path(UserWorkspaceIdPathSchema())
+    @hapic.output_body(NoContentSchema(), default_http_code=HTTPStatus.NO_CONTENT)  # nopep8
+    def enable_workspace_notification(self, context, request: TracimRequest, hapic_data=None):  # nopep8
+        """
+        enable workspace notification
+        """
+        app_config = request.registry.settings['CFG']
+        api = ContentApi(
+            current_user=request.candidate_user,  # User
+            session=request.dbsession,
+            config=app_config,
+        )
+        wapi = WorkspaceApi(
+            current_user=request.candidate_user,  # User
+            session=request.dbsession,
+            config=app_config,
+        )
+        workspace = wapi.get_one(hapic_data.path.workspace_id)
+        wapi.enable_notifications(request.candidate_user, workspace)
+        rapi = RoleApi(
+            current_user=request.candidate_user,  # User
+            session=request.dbsession,
+            config=app_config,
+        )
+        role = rapi.get_one(request.candidate_user.user_id, workspace.workspace_id)
+        wapi.save(workspace)
+        return
+
+    @hapic.with_api_doc(tags=[SWAGGER_TAG__USER_ENDPOINTS])
+    @require_same_user_or_profile(Group.TIM_ADMIN)
+    @hapic.input_path(UserWorkspaceIdPathSchema())
+    @hapic.output_body(NoContentSchema(), default_http_code=HTTPStatus.NO_CONTENT)  # nopep8
+    def disable_workspace_notification(self, context, request: TracimRequest, hapic_data=None):  # nopep8
+        """
+        disable workspace notification
+        """
+        app_config = request.registry.settings['CFG']
+        api = ContentApi(
+            current_user=request.candidate_user,  # User
+            session=request.dbsession,
+            config=app_config,
+        )
+        wapi = WorkspaceApi(
+            current_user=request.candidate_user,  # User
+            session=request.dbsession,
+            config=app_config,
+        )
+        workspace = wapi.get_one(hapic_data.path.workspace_id)
+        wapi.disable_notifications(request.candidate_user, workspace)
+        wapi.save(workspace)
+        return
+
     def bind(self, configurator: Configurator) -> None:
         """
         Create all routes and views using pyramid configurator
@@ -532,3 +587,11 @@ class UserController(Controller):
         # set workspace as read
         configurator.add_route('read_workspace', '/users/{user_id}/workspaces/{workspace_id}/read', request_method='PUT')  # nopep8
         configurator.add_view(self.set_workspace_as_read, route_name='read_workspace')  # nopep8
+
+        # enable workspace notification
+        configurator.add_route('enable_workspace_notification', '/users/{user_id}/workspaces/{workspace_id}/notify', request_method='PUT')  # nopep8
+        configurator.add_view(self.enable_workspace_notification, route_name='enable_workspace_notification')  # nopep8
+
+        # enable workspace notification
+        configurator.add_route('disable_workspace_notification', '/users/{user_id}/workspaces/{workspace_id}/unnotify', request_method='PUT')  # nopep8
+        configurator.add_view(self.disable_workspace_notification, route_name='disable_workspace_notification')  # nopep8

--- a/backend/tracim_backend/views/core_api/workspace_controller.py
+++ b/backend/tracim_backend/views/core_api/workspace_controller.py
@@ -221,8 +221,7 @@ class WorkspaceController(Controller):
         workspace_role = WorkspaceRoles.get_role_from_slug(hapic_data.body.role)
         role = rapi.update_role(
             role,
-            role_level=workspace_role.level,
-            with_notif=hapic_data.body.do_notify
+            role_level=workspace_role.level
         )
         return rapi.get_user_role_workspace_with_context(role)
 
@@ -303,7 +302,7 @@ class WorkspaceController(Controller):
             user=user,
             workspace=request.current_workspace,
             role_level=WorkspaceRoles.get_role_from_slug(hapic_data.body.role).level,  # nopep8
-            with_notif=hapic_data.body.do_notify or False,  # nopep8, default value as false
+            with_notif=False,
             flush=True,
         )
         return rapi.get_user_role_workspace_with_context(


### PR DESCRIPTION
Add few endpoints + some fix :
- [X] fix small bug in WorkspaceAndUserPath model.
- [X] disable do_notify in edit/update for workspace members endpoint, related to tracim/tracim#834
- [X]  add endpoint to get user_role for a specified workspace
- [X] add endpoint to get all workspace of tracim instance for global admin, related to tracim/tracim/835
- [X] add endpoints to enable or disable user notification in workspace , related to tracim/tracim#834