### PR TITLE
WIP: Fix/958 better file name handling

### DIFF
--- a/backend/tracim_backend/app_models/applications.py
+++ b/backend/tracim_backend/app_models/applications.py
@@ -55,6 +55,7 @@ class Application(object):
             available_statuses: typing.List['ContentStatus'],
             slug_alias: typing.List[str] = None,
             allow_sub_content: bool = False,
+            default_file_extension: typing.Optional[str] = None,
     ):
         content_type = ContentType(
             slug=slug,
@@ -65,6 +66,7 @@ class Application(object):
             available_statuses=available_statuses,
             slug_alias=slug_alias,
             allow_sub_content=allow_sub_content,
+            default_file_extension=default_file_extension,
         )
         self.content_types.append(content_type)
 

--- a/backend/tracim_backend/app_models/contents.py
+++ b/backend/tracim_backend/app_models/contents.py
@@ -124,6 +124,7 @@ class ContentType(object):
             available_statuses: typing.List[ContentStatus],
             slug_alias: typing.List[str] = None,
             allow_sub_content: bool = False,
+            default_file_extension: typing.Optional[str] = None,
     ):
         self.slug = slug
         self.fa_icon = fa_icon
@@ -133,6 +134,7 @@ class ContentType(object):
         self.available_statuses = available_statuses
         self.slug_alias = slug_alias
         self.allow_sub_content = allow_sub_content
+        self.default_file_extension = default_file_extension
 
 
 THREAD_TYPE = 'thread'

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -609,7 +609,8 @@ class CFG(object):
             label='Text Document',
             creation_label='Write a document',
             available_statuses=content_status_list.get_all(),
-            slug_alias=['page']
+            slug_alias=['page'],
+            default_file_extension='.document.html',
         )
 
         _file = Application(
@@ -642,6 +643,7 @@ class CFG(object):
             label='Thread',
             creation_label='Start a topic',
             available_statuses=content_status_list.get_all(),
+            default_file_extension='.thread.html'
         )
 
         folder = Application(

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -583,7 +583,7 @@ class ContentApi(object):
             content.label = label
             content.file_extension = file_extension
         elif filename:
-            self._is_filename_available(
+            self._is_filename_available_or_raise(
                 filename,
                 workspace,
                 parent
@@ -593,7 +593,6 @@ class ContentApi(object):
             content.file_name = filename
         else:
             if content_type_slug == content_type_list.Comment.slug:
-                content = Content()
                 # INFO - G.M - 2018-07-16 - Default label for comments is
                 # empty string.
                 content.label = ''

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -456,10 +456,10 @@ class ContentApi(object):
             query = query.filter(Content.content_id != exclude_content_id)
         query = query.filter(Content.workspace_id == workspace.workspace_id)
 
-        nb_content_with_the_filename = query.\
-            filter(Content.label == label).\
-            filter(Content.file_extension == file_extension).\
-            count()
+
+        nb_content_with_the_filename = query.filter(
+            Content.file_name == filename
+        ).count()
         if nb_content_with_the_filename == 0:
             return True
         elif nb_content_with_the_filename == 1:

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -873,7 +873,7 @@ class ContentApi(object):
         Apply normalised filters to found Content corresponding as given label.
         :param query: query to modify
         :param content_label_as_file: label in this
-        FILE version, use Content.get_label_as_file().
+        FILE version, use Content.file_name.
         :param is_case_sensitive: Take care about case or not
         :return: modified query
         """

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -566,22 +566,28 @@ class ContentApi(object):
                         content_id=workspace.workspace_id,
                     )
                 )
-        content = None
-        if filename or label:
-            if label:
-                file_extension = ''
-                if content_type.slug in (
-                        content_type_list.Page.slug,
-                        content_type_list.Thread.slug,
-                ):
-                    file_extension = '.html'
-                filename = self._prepare_filename(label, file_extension)
+        content = Content()
+        if label:
+            file_extension = ''
+            if content_type.default_file_extension:
+                file_extension = content_type.default_file_extension
+            filename = self._prepare_filename(label, file_extension)
             self._is_filename_available_or_raise(
                 filename,
                 workspace,
                 parent,
             )
-            content = Content()
+            # TODO - G.M - 2018-10-15 - Set file extension and label
+            # explicitly instead of filename in order to have correct
+            # label/file-extension separation.
+            content.label = label
+            content.file_extension = file_extension
+        elif filename:
+            self._is_filename_available(
+                filename,
+                workspace,
+                parent
+            )
             # INFO - G.M - 2018-07-04 - File_name setting automatically
             # set label and file_extension
             content.file_name = filename

--- a/backend/tracim_backend/lib/webdav/resources.py
+++ b/backend/tracim_backend/lib/webdav/resources.py
@@ -239,7 +239,7 @@ class WorkspaceResource(DAVCollection):
             # the purpose is to display .history only if there's at least one content's type that has a history
             if content.type != content_type_list.Folder.slug:
                 self._file_count += 1
-            retlist.append(content.get_label_as_file())
+            retlist.append(content.file_name)
 
         return retlist
 
@@ -327,7 +327,7 @@ class WorkspaceResource(DAVCollection):
         children = self.content_api.get_all(False, content_type_list.Any_SLUG, self.workspace)
 
         for content in children:
-            content_path = '%s/%s' % (self.path, transform_to_display(content.get_label_as_file()))
+            content_path = '%s/%s' % (self.path, transform_to_display(content.file_name))
 
             if content.type == content_type_list.Folder.slug:
                 members.append(
@@ -434,7 +434,7 @@ class FolderResource(WorkspaceResource):
         return mktime(self.content.created.timetuple())
 
     def getDisplayName(self) -> str:
-        return transform_to_display(self.content.get_label_as_file())
+        return transform_to_display(self.content.file_name)
 
     def getLastModified(self) -> float:
         return mktime(self.content.updated.timetuple())
@@ -551,7 +551,7 @@ class FolderResource(WorkspaceResource):
         )
 
         for content in visible_children:
-            content_path = '%s/%s' % (self.path, transform_to_display(content.get_label_as_file()))
+            content_path = '%s/%s' % (self.path, transform_to_display(content.file_name))
 
             try:
                 if content.type == content_type_list.Folder.slug:
@@ -692,7 +692,7 @@ class HistoryFolderResource(FolderResource):
         )
 
         return HistoryFileFolderResource(
-            path='%s/%s' % (self.path, content.get_label_as_file()),
+            path='%s/%s' % (self.path, content.file_name),
             environ=self.environ,
             content=content,
             session=self.session,
@@ -708,7 +708,7 @@ class HistoryFolderResource(FolderResource):
                 self._is_deleted and content.is_deleted or
                 not (content.is_archived or self._is_archived or content.is_deleted or self._is_deleted))\
                     and content.type != content_type_list.Folder.slug:
-                ret.append(content.get_label_as_file())
+                ret.append(content.file_name)
 
         return ret
 
@@ -741,7 +741,7 @@ class HistoryFolderResource(FolderResource):
         for content in children:
             if content.is_archived == self._is_archived and content.is_deleted == self._is_deleted:
                 members.append(HistoryFileFolderResource(
-                    path='%s/%s' % (self.path, content.get_label_as_file()),
+                    path='%s/%s' % (self.path, content.file_name),
                     environ=self.environ,
                     content=content,
                     user=self.user,
@@ -797,7 +797,7 @@ class DeletedFolderResource(HistoryFolderResource):
         )
 
         return self.provider.getResourceInst(
-            path='%s/%s' % (self.path, transform_to_display(content.get_label_as_file())),
+            path='%s/%s' % (self.path, transform_to_display(content.file_name)),
             environ=self.environ
             )
 
@@ -811,7 +811,7 @@ class DeletedFolderResource(HistoryFolderResource):
 
         for content in children:
             if content.is_deleted:
-                retlist.append(content.get_label_as_file())
+                retlist.append(content.file_name)
 
                 if content.type != content_type_list.Folder.slug:
                     self._file_count += 1
@@ -828,7 +828,7 @@ class DeletedFolderResource(HistoryFolderResource):
 
         for content in children:
             if content.is_deleted:
-                content_path = '%s/%s' % (self.path, transform_to_display(content.get_label_as_file()))
+                content_path = '%s/%s' % (self.path, transform_to_display(content.file_name))
 
                 if content.type == content_type_list.Folder.slug:
                     members.append(
@@ -923,7 +923,7 @@ class ArchivedFolderResource(HistoryFolderResource):
         )
 
         return self.provider.getResourceInst(
-            path=self.path + '/' + transform_to_display(content.get_label_as_file()),
+            path=self.path + '/' + transform_to_display(content.file_name),
             environ=self.environ
         )
 
@@ -932,7 +932,7 @@ class ArchivedFolderResource(HistoryFolderResource):
 
         for content in self.content_api.get_all_with_filter(
                 self.content if self.content is None else self.content.id, content_type_list.Any_SLUG):
-            retlist.append(content.get_label_as_file())
+            retlist.append(content.file_name)
 
             if content.type != content_type_list.Folder.slug:
                 self._file_count += 1
@@ -949,7 +949,7 @@ class ArchivedFolderResource(HistoryFolderResource):
 
         for content in children:
             if content.is_archived:
-                content_path = '%s/%s' % (self.path, transform_to_display(content.get_label_as_file()))
+                content_path = '%s/%s' % (self.path, transform_to_display(content.file_name))
 
                 if content.type == content_type_list.Folder.slug:
                     members.append(
@@ -1025,7 +1025,7 @@ class HistoryFileFolderResource(HistoryFolderResource):
         return "<DAVCollection: HistoryFileFolderResource (%s)" % self.content.file_name
 
     def getDisplayName(self) -> str:
-        return self.content.get_label_as_file()
+        return self.content.file_name
 
     def createCollection(self, name):
         raise DAVError(HTTP_FORBIDDEN)
@@ -1059,7 +1059,7 @@ class HistoryFileFolderResource(HistoryFolderResource):
             )
         else:
             return HistoryOtherFile(
-                path='%s%s' % (left_side, transform_to_display(revision.get_label_as_file())),
+                path='%s%s' % (left_side, transform_to_display(revision.file_name)),
                 environ=self.environ,
                 content=self.content,
                 content_revision=revision,
@@ -1154,7 +1154,7 @@ class FileResource(DAVNonCollection):
         return FakeFileStream(
             content=self.content,
             content_api=self.content_api,
-            file_name=self.content.get_label_as_file(),
+            file_name=self.content.file_name,
             workspace=self.content.workspace,
             path=self.path,
             session=self.session,
@@ -1398,7 +1398,7 @@ class OtherFileResource(FileResource):
             self.path += '.html'
 
     def getDisplayName(self) -> str:
-        return self.content.get_label_as_file()
+        return self.content.file_name
 
     def getPreferredPath(self):
         return self.path
@@ -1456,7 +1456,7 @@ class HistoryOtherFile(OtherFileResource):
 
     def getDisplayName(self) -> str:
         left_side = '(%d - %s) ' % (self.content_revision.revision_id, self.content_revision.revision_type)
-        return '%s%s' % (left_side, transform_to_display(self.content_revision.get_label_as_file()))
+        return '%s%s' % (left_side, transform_to_display(self.content_revision.file_name))
 
     def getContent(self):
         filestream = compat.BytesIO()

--- a/backend/tracim_backend/migration/versions/47b6cb15db5a_change_default_file_extension_in_.py
+++ b/backend/tracim_backend/migration/versions/47b6cb15db5a_change_default_file_extension_in_.py
@@ -1,0 +1,63 @@
+"""change default file_extension in database
+
+Revision ID: 47b6cb15db5a
+Revises: 8957d4adbc77
+Create Date: 2018-10-10 16:50:35.902270
+
+"""
+
+# revision identifiers, used by Alembic.
+
+revision = '47b6cb15db5a'
+down_revision = '8957d4adbc77'
+
+from alembic import op
+import sqlalchemy as sa
+
+revisions = sa.Table(
+    'content_revisions',
+    sa.MetaData(),
+    sa.Column('revision_id', sa.Integer, primary_key=True),
+    sa.Column('type', sa.Unicode(32), unique=False, nullable=False),
+    sa.Column('file_extension', sa.Unicode(255), unique=False, nullable=False, server_default=''),  # nopep8
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute(
+        revisions.update()
+        .where(
+            revisions.c.type == 'html-document'
+        ).values(
+            file_extension='.document.html',
+        )
+    )
+    connection.execute(
+        revisions.update()
+        .where(
+            revisions.c.type == 'thread'
+        ).values(
+            file_extension='.thread.html',
+        )
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute(
+        revisions.update()
+        .where(
+            revisions.c.type == 'html-document'
+        ).values(
+            file_extension='.html',
+        )
+    )
+    connection.execute(
+        revisions.update()
+        .where(
+            revisions.c.type == 'thread'
+        ).values(
+            file_extension='.html',
+        )
+    )

--- a/backend/tracim_backend/models/data.py
+++ b/backend/tracim_backend/models/data.py
@@ -643,12 +643,23 @@ class ContentRevisionRO(DeclarativeBase):
             RevisionReadStatus(user=k, view_datetime=v)
     )
 
-    @property
-    def file_name(self):
+    @hybrid_property
+    def file_name(self) -> str:
         return '{0}{1}'.format(
             self.label,
             self.file_extension,
         )
+
+    @file_name.setter
+    def file_name(self, value: str) -> None:
+        file_name, file_extension = os.path.splitext(value)
+        self.label = file_name
+        self.file_extension = file_extension
+
+    @file_name.expression
+    def file_name(cls) -> InstrumentedAttribute:
+        return ContentRevisionRO.label + ContentRevisionRO.file_extension
+
 
     @classmethod
     def new_from(cls, revision: 'ContentRevisionRO') -> 'ContentRevisionRO':
@@ -881,20 +892,17 @@ class Content(DeclarativeBase):
 
     @hybrid_property
     def file_name(self) -> str:
-        return '{0}{1}'.format(
-            self.revision.label,
-            self.revision.file_extension,
-        )
+        return self.revision.file_name
 
     @file_name.setter
     def file_name(self, value: str) -> None:
         file_name, file_extension = os.path.splitext(value)
-        self.revision.label = file_name
-        self.revision.file_extension = file_extension
+        self.label = file_name
+        self.file_extension = file_extension
 
     @file_name.expression
     def file_name(cls) -> InstrumentedAttribute:
-        return ContentRevisionRO.file_name + ContentRevisionRO.file_extension
+        return Content.label + Content.file_extension
 
     @hybrid_property
     def file_extension(self) -> str:

--- a/backend/tracim_backend/models/data.py
+++ b/backend/tracim_backend/models/data.py
@@ -762,19 +762,6 @@ class ContentRevisionRO(DeclarativeBase):
 
         return False
 
-    def get_label_as_file(self):
-        file_extension = self.file_extension or ''
-
-        if self.type == content_type_list.Thread.slug:
-            file_extension = '.html'
-        elif self.type == content_type_list.Page.slug:
-            file_extension = '.html'
-
-        return '{0}{1}'.format(
-            self.label,
-            file_extension,
-        )
-
 # TODO - G.M - 2018-06-177 - [author] Owner should be renamed "author"
 Index('idx__content_revisions__owner_id', ContentRevisionRO.owner_id)
 Index('idx__content_revisions__parent_id', ContentRevisionRO.parent_id)
@@ -1230,12 +1217,6 @@ class Content(DeclarativeBase):
 
     def get_label(self):
         return self.label or self.file_name or ''
-
-    def get_label_as_file(self) -> str:
-        """
-        :return: Return content label in file representation context
-        """
-        return self.revision.get_label_as_file()
 
     def get_status(self) -> ContentStatus:
         return self.revision.get_status()

--- a/backend/tracim_backend/tests/functional/test_contents.py
+++ b/backend/tracim_backend/tests/functional/test_contents.py
@@ -1015,6 +1015,7 @@ class TestHtmlDocuments(FunctionalTest):
         assert content['last_modifier']['public_name'] == 'Bob i.'
         assert content['last_modifier']['avatar_url'] is None
         assert content['raw_content'] == '<p>To cook a great Tiramisu, you need many ingredients.</p>'  # nopep8
+        assert content['file_extension'] == '.document.html'
 
     def test_api__get_html_document__ok_200__nominal_case(self) -> None:
         """
@@ -1056,6 +1057,7 @@ class TestHtmlDocuments(FunctionalTest):
         assert content['last_modifier']['public_name'] == 'Bob i.'
         assert content['last_modifier']['avatar_url'] is None
         assert content['raw_content'] == '<p>To cook a great Tiramisu, you need many ingredients.</p>'  # nopep8
+        assert content['file_extension'] == '.document.html'
 
     def test_api__get_html_document__ok_200__archived_content(self) -> None:
         """
@@ -1286,6 +1288,7 @@ class TestHtmlDocuments(FunctionalTest):
         assert content['modified']
         assert content['last_modifier'] == content['author']
         assert content['raw_content'] == '<p> Le nouveau contenu </p>'
+        assert content['file_extension'] == '.document.html'
 
         res = self.testapp.get(
             '/api/v2/workspaces/2/html-documents/6',
@@ -1313,6 +1316,7 @@ class TestHtmlDocuments(FunctionalTest):
         assert content['modified']
         assert content['last_modifier'] == content['author']
         assert content['raw_content'] == '<p> Le nouveau contenu </p>'
+        assert content['file_extension'] == '.document.html'
 
     def test_api__update_html_document__err_400__not_modified(self) -> None:
         """
@@ -1478,6 +1482,7 @@ class TestHtmlDocuments(FunctionalTest):
         assert revision['author']['user_id'] == 3
         assert revision['author']['avatar_url'] is None
         assert revision['author']['public_name'] == 'Bob i.'
+        assert revision['file_extension'] == '.document.html'
 
     def test_api__set_html_document_status__ok_200__nominal_case(self) -> None:
         """
@@ -4678,6 +4683,7 @@ class TestThreads(FunctionalTest):
         assert content['last_modifier']['public_name'] == 'Bob i.'
         assert content['last_modifier']['avatar_url'] is None
         assert content['raw_content'] == 'What is the best cake?'  # nopep8
+        assert content['file_extension'] == '.thread.html'
 
     def test_api__get_thread__err_400__content_does_not_exist(self) -> None:
         """
@@ -4816,6 +4822,7 @@ class TestThreads(FunctionalTest):
         assert content['modified']
         assert content['last_modifier'] == content['author']
         assert content['raw_content'] == '<p> Le nouveau contenu </p>'
+        assert content['file_extension'] == '.thread.html'
 
         res = self.testapp.get(
             '/api/v2/workspaces/2/threads/7',
@@ -4843,6 +4850,7 @@ class TestThreads(FunctionalTest):
         assert content['modified']
         assert content['last_modifier'] == content['author']
         assert content['raw_content'] == '<p> Le nouveau contenu </p>'
+        assert content['file_extension'] == '.thread.html'
 
     def test_api__update_thread__err_400__not_modified(self) -> None:
         """
@@ -4988,6 +4996,7 @@ class TestThreads(FunctionalTest):
         assert revision['author']['user_id'] == 1
         assert revision['author']['avatar_url'] is None
         assert revision['author']['public_name'] == 'Global manager'
+        assert revision['file_extension'] == '.thread.html'
         revision = revisions[1]
         assert revision['content_type'] == 'thread'
         assert revision['content_id'] == 7
@@ -5009,6 +5018,7 @@ class TestThreads(FunctionalTest):
         assert revision['author']['user_id'] == 3
         assert revision['author']['avatar_url'] is None
         assert revision['author']['public_name'] == 'Bob i.'
+        assert revision['file_extension'] == '.thread.html'
 
     def test_api__get_thread_revisions__ok_200__most_revision_type(self) -> None:
         """

--- a/backend/tracim_backend/tests/functional/test_workspaces.py
+++ b/backend/tracim_backend/tests/functional/test_workspaces.py
@@ -3124,6 +3124,7 @@ class TestWorkspaceContents(FunctionalTest):
         assert res.json_body['parent_id'] is None
         assert res.json_body['show_in_ui'] is True
         assert res.json_body['sub_content_types']
+        assert res.json_body['file_extension'] == '.document.html'
         params_active = {
             'parent_id': 0,
             'show_archived': 0,
@@ -3167,6 +3168,7 @@ class TestWorkspaceContents(FunctionalTest):
         assert res.json_body['parent_id'] is None
         assert res.json_body['show_in_ui'] is True
         assert res.json_body['sub_content_types']
+        assert res.json_body['file_extension'] == '.document.html'
         params_active = {
             'parent_id': 0,
             'show_archived': 0,
@@ -3219,6 +3221,7 @@ class TestWorkspaceContents(FunctionalTest):
         assert res.json_body['parent_id'] is None
         assert res.json_body['show_in_ui'] is True
         assert res.json_body['sub_content_types']
+        assert res.json_body['file_extension'] == '.document.html'
         params_active = {
             'parent_id': 0,
             'show_archived': 0,
@@ -3289,6 +3292,7 @@ class TestWorkspaceContents(FunctionalTest):
         assert res.json_body['parent_id'] == 10
         assert res.json_body['show_in_ui'] is True
         assert res.json_body['sub_content_types']
+        assert res.json_body['file_extension'] == '.document.html'
         params_active = {
             'parent_id': 10,
             'show_archived': 0,

--- a/backend/tracim_backend/tests/library/test_webdav.py
+++ b/backend/tracim_backend/tests/library/test_webdav.py
@@ -270,8 +270,8 @@ class TestWebDav(StandardTest):
                 content_names,
         )
 
-        assert 'Best Cakesʔ.html' in content_names,\
-            'Best Cakesʔ.html should be in names ({0})'.format(
+        assert 'Best Cakesʔ.thread.html' in content_names,\
+            'Best Cakesʔ.thread.html should be in names ({0})'.format(
                 content_names,
         )
         assert 'Apple_Pie.txt' in content_names,\
@@ -282,8 +282,8 @@ class TestWebDav(StandardTest):
                 content_names,
         )
 
-        assert 'Tiramisu Recipe.html' in content_names,\
-            'Tiramisu Recipe.html should be in names ({0})'.format(
+        assert 'Tiramisu Recipe.document.html' in content_names,\
+            'Tiramisu Recipe.document.html should be in names ({0})'.format(
                 content_names,
         )
 

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -930,6 +930,9 @@ class ContentDigestSchema(marshmallow.Schema):
                     'for sub-contents. Default is True. '
                     'In first version of the API, this field is always True',
     )
+    file_extension = marshmallow.fields.String(
+        example='.txt'
+    )
 
 
 class ReadStatusSchema(marshmallow.Schema):
@@ -985,9 +988,6 @@ class FileInfoAbstractSchema(marshmallow.Schema):
     pdf_available = marshmallow.fields.Bool(
         description="Is pdf version of file available ?",
         example=True,
-    )
-    file_extension = marshmallow.fields.String(
-        example='.txt'
     )
 
 


### PR DESCRIPTION
related to tracim/tracim#958

- [X] remove get_label_as_file() which is a duplicate of file_name.
- [X] use new default file extension for content type like '.document.html' + migration script
- [X] add file extension in all endpoints
- [X] repair filename check sql query.

Todo : 
- [ ] Decide final file extension for both html page and thread.
- renaming on the fly, will be done in another pr: see https://github.com/tracim/tracim/issues/1022