### PR TITLE
rename reset password validity in config

### DIFF
--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -91,7 +91,7 @@ auth_type = internal
 # User auth token validity in seconds (used to interfaces like web calendars)
 user.auth_token.validity = 604800
 # user reset_password token validity (default to 900s -> 15 minutes)
-user.reset_password.validity = 900
+user.reset_password.token_validity = 900
 
 
 session.type = file

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -98,7 +98,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = False
 
 [functional_test_frontend_enabled]
@@ -113,7 +113,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = True
 
 [functional_test_with_cookie_auth]
@@ -136,7 +136,7 @@ session.cookie_expires = 600
 session.timeout = 600
 session.reissue_time = 120
 session.cookie_on_exception = true
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [functional_test_no_db]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -150,7 +150,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [functional_test_with_mail_test_sync]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -178,7 +178,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [functional_test_with_mail_test_async]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -206,7 +206,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [webdav_test]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -217,7 +217,7 @@ class CFG(object):
             '604800',
         ))
         self.USER_RESET_PASSWORD_TOKEN_VALIDITY = int(settings.get(
-            'user.reset_password.validity',
+            'user.reset_password.token_validity',
             '900'
         ))
 


### PR DESCRIPTION
related to tracim/tracim#970
to do:
- [X] rename `user.reset_password.validity` to `user.reset_password.token_validity`.
- [ ] support for legacy config file ?
- [ ] update documentation/changelog? about this change.